### PR TITLE
add logging dependency for local development and bump augur version

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ Example response:
 }
 ```
 
+## Local Development
+If you'd like to use a local version of [augur](https://github.com/block/bitcoin-augur) within your reference implementation:
+- Within augur, run `bin/gradle shadowJar` to build a fat jar of augur.
+- Copy the file `lib/build/libs/augur.jar` into this reference implementation `app/libs` directory.
+- Change
+  `implementation(libs.augur)` to `implementation(files("libs/augur.jar"))` in the `app/build.gradle.kts` [file](https://github.com/block/bitcoin-augur-reference/blob/main/app/build.gradle.kts).
+- Within the reference implementation, run `bin/gradle build` to build the project with the local version of augur.
+
 ## Project Structure
 
 - `config`: Configuration classes

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,6 +32,10 @@ dependencies {
     // This dependency is used by the application.
     implementation(libs.guava)
     implementation(libs.okhttp)
+
+    // This dependency is necessary when using a local jar of augur, e.g., implementation(files("libs/augur.jar"))
+    implementation(libs.slf4j.simple)
+
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.databind)
     implementation(libs.jackson.datatype.jsr310)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,11 +10,12 @@ spotless = "6.25.0" # Adding Spotless version
 kotlin-serialization = "1.9.22"
 okhttp = "4.12.0"
 jackson = "2.15.3"
-augur = "0.1.0"
+augur = "0.2.1"
 kotlinx-serialization-json = "1.6.0"
 kaml = "0.55.0"
 junit-platform-launcher = "1.10.3"
 kotlin-test-junit5 = "2.0.20"
+slf4j-simple = "1.7.36"
 
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
@@ -38,6 +39,7 @@ jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-dat
 augur = { module = "xyz.block:augur", version.ref = "augur" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j-simple" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.20" }


### PR DESCRIPTION
- Verified that using a local augur jar file within the reference implementation works.
- Also verified that this new augur version pulls in the custom target block [changes](https://github.com/block/bitcoin-augur/pull/2).