### PR TITLE
feat: GET /historical_fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,81 @@ Example response:
 }
 ```
 
+
+Historical fee estimates at:
+
+```
+GET /historical_fee?timestamp=<unix_timestamp>
+```
+
+Example response:
+```json
+
+{
+  "mempool_update_time" : "2025-08-16T14:05:44.854Z",
+  "estimates" : {
+    "3" : {
+      "probabilities" : {
+        "0.05" : {
+          "fee_rate" : 1.0
+        },
+        "0.20" : {
+          "fee_rate" : 1.0
+        },
+        "0.50" : {
+          "fee_rate" : 1.0
+        },
+        "0.80" : {
+          "fee_rate" : 1.0
+        },
+        "0.95" : {
+          "fee_rate" : 1.0
+        }
+      }
+    },
+    "6" : {
+      "probabilities" : {
+        "0.05" : {
+          "fee_rate" : 1.0
+        },
+        "0.20" : {
+          "fee_rate" : 1.0
+        },
+        "0.50" : {
+          "fee_rate" : 1.0
+        },
+        "0.80" : {
+          "fee_rate" : 1.0
+        },
+        "0.95" : {
+          "fee_rate" : 1.0
+        }
+      }
+    },
+    "9" : {
+      "probabilities" : {
+        "0.05" : {
+          "fee_rate" : 1.0
+        },
+        "0.20" : {
+          "fee_rate" : 1.0
+        },
+        "0.50" : {
+          "fee_rate" : 1.0
+        },
+        "0.80" : {
+          "fee_rate" : 1.0
+        },
+        "0.95" : {
+          "fee_rate" : 1.0
+        }
+      }
+    }
+  }
+}
+
+```
+
 ## Local Development
 If you'd like to use a local version of [augur](https://github.com/block/bitcoin-augur) within your reference implementation:
 - Within augur, run `bin/gradle shadowJar` to build a fat jar of augur.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,10 @@ dependencies {
     testImplementation(libs.ktor.client.core)
     testImplementation(libs.ktor.client.cio)
     testImplementation(libs.ktor.client.content.negotiation)
+
+    // MockK for mocking dependencies
+    testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/app/src/main/kotlin/xyz/block/augurref/api/HistoricalFeeEndpoint.kt
+++ b/app/src/main/kotlin/xyz/block/augurref/api/HistoricalFeeEndpoint.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.block.augurref.api
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import org.slf4j.LoggerFactory
+import xyz.block.augurref.service.MempoolCollector
+
+/**
+ * Configure historical fee estimate endpoint
+ */
+fun Route.configureHistoricalFeesEndpoint(mempoolCollector: MempoolCollector) {
+  val logger = LoggerFactory.getLogger("xyz.block.augurref.api.HistoricalFeeEstimateEndpoint")
+
+  get("/historical_fee") {
+    logger.info("Received request for historical fee estimates")
+
+    // Extract unix timestamp param from query parameters
+    val timestampParam = call.request.queryParameters["timestamp"]
+
+    if (timestampParam == null) {
+      call.respondText(
+        "timestamp parameter is required",
+        status = HttpStatusCode.BadRequest,
+        contentType = ContentType.Text.Plain,
+      )
+      return@get
+    }
+    val timestamp = timestampParam.toLongOrNull()
+
+    // Fetch historical fee estimate based on unix timestamp
+    val feeEstimate = if (timestamp != null) {
+      logger.info("Fetching historical fee estimate for timestamp: $timestamp")
+      mempoolCollector.getFeeEstimateForTimestamp(timestamp)
+    } else {
+      logger.warn("timestamp is null")
+      call.respondText(
+        "Failed to parse timestamp, please input a unix timestamp",
+        status = HttpStatusCode.BadRequest,
+        contentType = ContentType.Text.Plain,
+      )
+      return@get
+    }
+
+    if (feeEstimate == null) {
+      logger.warn("No historical fee estimates available for $timestamp")
+      call.respondText(
+        "No historical fee estimates available for $timestamp",
+        status = HttpStatusCode.ServiceUnavailable,
+        contentType = ContentType.Text.Plain,
+      )
+    } else {
+      logger.info("Transforming historical fee estimates for response")
+      val response = transformFeeEstimate(feeEstimate)
+      logger.debug("Returning historical fee estimates with ${response.estimates.size} targets")
+      call.respond(response)
+    }
+  }
+}

--- a/app/src/main/kotlin/xyz/block/augurref/server/HttpServer.kt
+++ b/app/src/main/kotlin/xyz/block/augurref/server/HttpServer.kt
@@ -26,6 +26,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import org.slf4j.LoggerFactory
 import xyz.block.augurref.api.configureFeesEndpoint
+import xyz.block.augurref.api.configureHistoricalFeesEndpoint
 import xyz.block.augurref.config.ServerConfig
 import xyz.block.augurref.service.MempoolCollector
 
@@ -58,6 +59,7 @@ class HttpServer(
       // Configure routes
       routing {
         configureFeesEndpoint(mempoolCollector)
+        configureHistoricalFeesEndpoint(mempoolCollector)
       }
     }.start(wait = false)
 

--- a/app/src/test/kotlin/xyz/block/augurref/api/HistoricalFeeEstimateEndpointTest.kt
+++ b/app/src/test/kotlin/xyz/block/augurref/api/HistoricalFeeEstimateEndpointTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025 Block, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.block.augurref.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.jackson.jackson
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.TestApplicationBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import xyz.block.augur.FeeEstimate
+import xyz.block.augurref.service.MempoolCollector
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FeeEstimateEndpointTest {
+  private val mockMempoolCollector = mockk<MempoolCollector>()
+  private val objectMapper = ObjectMapper().apply {
+    registerModule(KotlinModule.Builder().build())
+    registerModule(JavaTimeModule())
+  }
+
+  companion object {
+    object TestData {
+      object FeeRates {
+        const val LOW_BLOCK1 = 10.5
+        const val HIGH_BLOCK1 = 15.25
+        const val LOW_BLOCK6 = 5.75
+        const val HIGH_BLOCK6 = 8.1234
+      }
+
+      object Probabilities {
+        const val MEDIUM = 0.5
+        const val HIGH = 0.9
+      }
+
+      object BlockTargets {
+        const val TARGET_1 = 1
+        const val TARGET_6 = 6
+      }
+    }
+  }
+
+  /**
+   * Configures the test application with the same JSON serialization
+   * settings as the main server and sets up the fees endpoint routing.
+   */
+  private fun TestApplicationBuilder.configureTestApplication() {
+    application {
+      // Configure JSON serialization (same as main server)
+      install(ContentNegotiation) {
+        jackson {
+          registerModule(JavaTimeModule())
+          disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+          enable(SerializationFeature.INDENT_OUTPUT)
+        }
+      }
+
+      routing {
+        configureHistoricalFeesEndpoint(mockMempoolCollector)
+      }
+    }
+  }
+
+  @Test
+  fun `should return historical fee estimates when available`() = testApplication {
+    val fixedInstant = Instant.parse("2025-01-15T10:00:00.123Z")
+    val fixedInstantUnixTimestamp = fixedInstant.toEpochMilli()
+    val mockFeeEstimate = createMockFeeEstimate(fixedInstant)
+    every { mockMempoolCollector.getFeeEstimateForTimestamp(fixedInstantUnixTimestamp) } returns mockFeeEstimate
+
+    configureTestApplication()
+
+    client.get("/historical_fee?timestamp=$fixedInstantUnixTimestamp").apply {
+      assertEquals(HttpStatusCode.OK, status)
+      val responseBody = bodyAsText()
+      val response: FeeEstimateResponse = objectMapper.readValue(responseBody)
+
+      assertEquals(fixedInstant, response.mempoolUpdateTime)
+      assertEquals(2, response.estimates.size)
+      assertTrue(response.estimates.containsKey("1"))
+      assertTrue(response.estimates.containsKey("6"))
+
+      val firstBlock = response.estimates["1"]!!
+      assertEquals(2, firstBlock.probabilities.size)
+      assertEquals(TestData.FeeRates.LOW_BLOCK1, firstBlock.probabilities["0.50"]?.feeRate)
+      assertEquals(TestData.FeeRates.HIGH_BLOCK1, firstBlock.probabilities["0.90"]?.feeRate)
+    }
+
+    verify { mockMempoolCollector.getFeeEstimateForTimestamp(fixedInstantUnixTimestamp) }
+  }
+
+  @Test
+  fun `should return 503 when no historical estimates available`() = testApplication {
+    val fixedInstant = Instant.parse("2025-01-15T10:00:00.123Z")
+    val fixedInstantUnixTimestamp = fixedInstant.toEpochMilli()
+    every { mockMempoolCollector.getFeeEstimateForTimestamp(fixedInstantUnixTimestamp) } returns null
+
+    configureTestApplication()
+
+    client.get("/historical_fee?timestamp=$fixedInstantUnixTimestamp").apply {
+      assertEquals(HttpStatusCode.ServiceUnavailable, status)
+      assertEquals("No historical fee estimates available for $fixedInstantUnixTimestamp", bodyAsText())
+    }
+
+    verify { mockMempoolCollector.getFeeEstimateForTimestamp(fixedInstantUnixTimestamp) }
+  }
+
+  @Test
+  fun `should return 400 when timestamp param is malformed or null`() = testApplication {
+    val fixedInstant = Instant.parse("2025-01-15T10:00:00.123Z")
+    val fixedInstantUnixTimestamp = fixedInstant.toEpochMilli()
+    every { mockMempoolCollector.getFeeEstimateForTimestamp(fixedInstantUnixTimestamp) } returns null
+
+    configureTestApplication()
+
+    client.get("/historical_fee?timestamp=$fixedInstant").apply {
+      assertEquals(HttpStatusCode.BadRequest, status)
+      assertEquals("Failed to parse timestamp, please input a unix timestamp", bodyAsText())
+    }
+    client.get("/historical_fee").apply {
+      assertEquals(HttpStatusCode.BadRequest, status)
+      assertEquals("timestamp parameter is required", bodyAsText())
+    }
+  }
+
+  private fun createMockFeeEstimate(timestamp: Instant): FeeEstimate {
+    // Create mock data using the actual augur library structure
+    val mockFeeEstimate = mockk<FeeEstimate>()
+
+    // Mock the properties that are accessed in the transformation
+    every { mockFeeEstimate.timestamp } returns timestamp
+
+    // Create mock estimates map - this is what the transformation function expects
+    val mockBlockTarget1 = mockk<xyz.block.augur.BlockTarget>()
+    every { mockBlockTarget1.probabilities } returns mapOf(
+      TestData.Probabilities.MEDIUM to TestData.FeeRates.LOW_BLOCK1,
+      TestData.Probabilities.HIGH to TestData.FeeRates.HIGH_BLOCK1,
+    )
+
+    val mockBlockTarget6 = mockk<xyz.block.augur.BlockTarget>()
+    every { mockBlockTarget6.probabilities } returns mapOf(
+      TestData.Probabilities.MEDIUM to TestData.FeeRates.LOW_BLOCK6,
+      TestData.Probabilities.HIGH to TestData.FeeRates.HIGH_BLOCK6,
+    )
+
+    every { mockFeeEstimate.estimates } returns mapOf(
+      TestData.BlockTargets.TARGET_1 to mockBlockTarget1,
+      TestData.BlockTargets.TARGET_6 to mockBlockTarget6,
+    )
+
+    return mockFeeEstimate
+  }
+}


### PR DESCRIPTION
## Description
related and closes https://github.com/block/bitcoin-augur-reference/issues/2

I wanted a way to retrieve historical estimates. 
This PR introduces a new endpoint `GET /historical_fee` that takes the `date` query parameter to query for historical fee estimates.

## Details
Add `date=<utc timestamp>` query param
```
GET 
/historical_fee?date=<utc timestamp>
```

will get you the same response as `GET /fees` but with an estimation from the provided date

## Example request

`http://100.97.107.124:8080/historical_fee?date=1755353169`

<details>
  <summary>Example response</summary>
  
```
{
  "mempool_update_time" : "2025-08-08T15:10:10.639Z",
  "estimates" : {
    "3" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 2.0536
        },
        "0.20" : {
          "fee_rate" : 3.8163
        },
        "0.50" : {
          "fee_rate" : 4.2922
        },
        "0.80" : {
          "fee_rate" : 5.0075
        },
        "0.95" : {
          "fee_rate" : 6.0853
        }
      }
    },
    "6" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.9226
        },
        "0.20" : {
          "fee_rate" : 2.3777
        },
        "0.50" : {
          "fee_rate" : 3.8457
        },
        "0.80" : {
          "fee_rate" : 4.8669
        },
        "0.95" : {
          "fee_rate" : 5.9614
        }
      }
    },
    "9" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.5556
        },
        "0.20" : {
          "fee_rate" : 1.9986
        },
        "0.50" : {
          "fee_rate" : 3.0743
        },
        "0.80" : {
          "fee_rate" : 4.7505
        },
        "0.95" : {
          "fee_rate" : 5.1867
        }
      }
    },
    "12" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.0186
        },
        "0.20" : {
          "fee_rate" : 1.8217
        },
        "0.50" : {
          "fee_rate" : 2.8466
        },
        "0.80" : {
          "fee_rate" : 3.692
        },
        "0.95" : {
          "fee_rate" : 4.6578
        }
      }
    },
    "18" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.0154
        },
        "0.20" : {
          "fee_rate" : 1.7262
        },
        "0.50" : {
          "fee_rate" : 2.4272
        },
        "0.80" : {
          "fee_rate" : 3.4497
        },
        "0.95" : {
          "fee_rate" : 4.2684
        }
      }
    },
    "24" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.014
        },
        "0.20" : {
          "fee_rate" : 1.6423
        },
        "0.50" : {
          "fee_rate" : 1.7875
        },
        "0.80" : {
          "fee_rate" : 3.2517
        },
        "0.95" : {
          "fee_rate" : 3.4585
        }
      }
    },
    "36" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.0
        },
        "0.20" : {
          "fee_rate" : 1.4825
        },
        "0.50" : {
          "fee_rate" : 1.521
        },
        "0.80" : {
          "fee_rate" : 2.0404
        },
        "0.95" : {
          "fee_rate" : 2.9985
        }
      }
    },
    "48" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.0
        },
        "0.20" : {
          "fee_rate" : 1.3649
        },
        "0.50" : {
          "fee_rate" : 1.3848
        },
        "0.80" : {
          "fee_rate" : 1.741
        },
        "0.95" : {
          "fee_rate" : 2.7334
        }
      }
    },
    "72" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.0
        },
        "0.20" : {
          "fee_rate" : 1.1532
        },
        "0.50" : {
          "fee_rate" : 1.2032
        },
        "0.80" : {
          "fee_rate" : 1.2808
        },
        "0.95" : {
          "fee_rate" : 1.5801
        }
      }
    },
    "96" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.0
        },
        "0.20" : {
          "fee_rate" : 1.0385
        },
        "0.50" : {
          "fee_rate" : 1.0821
        },
        "0.80" : {
          "fee_rate" : 1.1039
        },
        "0.95" : {
          "fee_rate" : 1.2255
        }
      }
    },
    "144" : {
      "probabilities" : {
        "0.05" : {
          "fee_rate" : 1.0
        },
        "0.20" : {
          "fee_rate" : 1.0
        },
        "0.50" : {
          "fee_rate" : 1.0
        },
        "0.80" : {
          "fee_rate" : 1.0101
        },
        "0.95" : {
          "fee_rate" : 1.0202
        }
      }
    }
  }
}
```
</details>

## TODO

Note this is still a draft, I still need to do a few things, but wanted to put it out there for any draft staged review
- [ ] write some testing
- [ ] clean up the code


Follow-up:
Create another endpoint for multiple historical fees (rebase after this merges) https://github.com/block/bitcoin-augur-reference/pull/11
`GET /historical_fees?start_date=<utc timestamp>&end_date=<utc timestamp>&interval=<1h,20m,30s>`